### PR TITLE
Fix default values not working with intellisense

### DIFF
--- a/.changeset/strong-toes-turn.md
+++ b/.changeset/strong-toes-turn.md
@@ -1,0 +1,5 @@
+---
+"tailwind-ink": patch
+---
+
+Fix default values not working with intellisense (grow and shrink utilities)

--- a/src/intellisense/shared.ts
+++ b/src/intellisense/shared.ts
@@ -93,6 +93,9 @@ export function numericUtility(
     values?: DynamicUtilityValues;
   } = {},
 ): DynamicUtility {
+  const valuesWithDefault = { ...values };
+  if (options.defaultValue)
+    valuesWithDefault.DEFAULT = String(options.defaultValue);
   return [
     (value) => {
       const transformer = numericTransformer(property, options);
@@ -109,7 +112,7 @@ export function numericUtility(
         return `${key}: ${value}`;
       }
     },
-    values,
+    valuesWithDefault,
   ];
 }
 


### PR DESCRIPTION
Fixes #3

This pull request fixes an issue where default values were not working with intellisense, affecting the `grow` and `shrink` utilities.

The issue was caused by the default values not being properly set in the values object. This PR adds a check for the default value and sets it in the values object (as `DEFAULT` by Tailwind CSS convention) if it exists.